### PR TITLE
fix: intermittent stale push statusline after commit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -102,6 +102,10 @@ impl App {
         if self.last_refresh.elapsed() < Duration::from_millis(300) {
             return;
         }
+        self.refresh_now();
+    }
+
+    fn refresh_now(&mut self) {
         self.last_refresh = Instant::now();
 
         match load_snapshot_with_options(&self.repo_root, self.show_unstaged_only) {
@@ -121,8 +125,7 @@ impl App {
     }
 
     pub fn force_refresh(&mut self) {
-        self.last_refresh = Instant::now() - Duration::from_secs(10);
-        self.refresh();
+        self.refresh_now();
     }
 
     pub fn files(&self) -> &[FileStat] {
@@ -360,6 +363,7 @@ impl App {
             return;
         }
 
+        let previous_unpushed = self.snapshot.unpushed_commits;
         let result = commit(&self.repo_root, &message);
         let succeeded = result.succeeded;
         self.ui.commit_dialog = Some(CommitDialog::Result {
@@ -368,7 +372,19 @@ impl App {
         });
 
         if succeeded {
-            self.force_refresh();
+            self.refresh_unpushed_after_commit(previous_unpushed, |app| app.force_refresh());
+        }
+    }
+
+    fn refresh_unpushed_after_commit<F>(&mut self, previous_unpushed: Option<u32>, mut refresh: F)
+    where
+        F: FnMut(&mut Self),
+    {
+        refresh(self);
+
+        if matches!((previous_unpushed, self.snapshot.unpushed_commits), (Some(before), Some(after)) if after <= before)
+        {
+            refresh(self);
         }
     }
 
@@ -1696,6 +1712,36 @@ mod tests {
         });
         app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert!(app.ui.commit_dialog.is_none());
+    }
+
+    #[test]
+    fn refresh_unpushed_after_commit_retries_when_first_refresh_is_stale() {
+        let mut app = make_app();
+        app.snapshot.unpushed_commits = Some(3);
+
+        let mut refresh_calls = 0;
+        app.refresh_unpushed_after_commit(Some(3), |app| {
+            refresh_calls += 1;
+            app.snapshot.unpushed_commits = if refresh_calls == 1 { Some(3) } else { Some(4) };
+        });
+
+        assert_eq!(refresh_calls, 2, "should retry refresh after stale result");
+        assert_eq!(app.snapshot.unpushed_commits, Some(4));
+    }
+
+    #[test]
+    fn refresh_unpushed_after_commit_does_not_retry_when_unpushed_advances() {
+        let mut app = make_app();
+        app.snapshot.unpushed_commits = Some(3);
+
+        let mut refresh_calls = 0;
+        app.refresh_unpushed_after_commit(Some(3), |app| {
+            refresh_calls += 1;
+            app.snapshot.unpushed_commits = Some(4);
+        });
+
+        assert_eq!(refresh_calls, 1, "single refresh should be enough");
+        assert_eq!(app.snapshot.unpushed_commits, Some(4));
     }
 
     #[test]


### PR DESCRIPTION
 #### Summary

 This fixes an intermittent issue where, after committing, the statusline sometimes failed to update the ↑N commits to push indicator right away.

 #### Root cause (observed behavior)

 Immediately after git commit, the first snapshot refresh could occasionally return stale upstream/ahead state, causing the statusline to continue showing the previous
 unpushed count.

 #### What changed

 - App::refresh refactor
     - Added refresh_now() for immediate refreshes.
     - refresh() still enforces debounce.
     - force_refresh() now uses direct non-debounced refresh.
 - Post-commit refresh hardening
     - In execute_commit(), capture previous_unpushed.
     - After successful commit, refresh once.
     - If unpushed count did not advance (after <= before), refresh a second time.
 - Testability + regression coverage
     - Extracted logic into refresh_unpushed_after_commit(...).
     - Added tests:
           - refresh_unpushed_after_commit_retries_when_first_refresh_is_stale
           - refresh_unpushed_after_commit_does_not_retry_when_unpushed_advances

 #### Why this is safe

 - Retry is narrowly scoped to successful commit flow.
 - Second refresh only occurs when the first result looks stale.
 - Existing debounce behavior for normal periodic refresh remains unchanged.

 #### Testing

 - Added targeted unit tests for retry/no-retry behavior.
 - Ran full suite:

 ```bash
   cargo test -q
 ```

 All tests pass.
